### PR TITLE
Fix Uninitialized string offset 0 when using date filter

### DIFF
--- a/src/Components/Filters/Builders/DatePicker.php
+++ b/src/Components/Filters/Builders/DatePicker.php
@@ -10,6 +10,10 @@ class DatePicker extends BuilderBase
 {
     public function builder(EloquentBuilder|QueryBuilder $builder, string $field, int|array|string|null $values): void
     {
+        if (gettype($values) === 'string') {
+            return;
+        }
+        
         /** @var array $values */
         [$startDate, $endDate] = [
             0 => Carbon::parse($values[0])->format('Y-m-d'),


### PR DESCRIPTION

#### Motivation

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This Pull Request fixes an error when using the Date filter together with global search.
When filtering by date, then removing this filter and using the global search, an "Uninitialized string offset 0" error occured.

#### Related Issue(s):  none

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
